### PR TITLE
Fixes cd on Windows if bazel's output is on different drive

### DIFF
--- a/multitool/private/run_in.template.bat
+++ b/multitool/private/run_in.template.bat
@@ -1,3 +1,3 @@
 @set tool=%cd%\{{tool}}
-@cd %{{env_var}}%
+@cd /D %{{env_var}}%
 @%tool% %*


### PR DESCRIPTION
Fixes https://github.com/theoremlp/rules_multitool/issues/73